### PR TITLE
Replace Slack reference with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 * Get help. Organizing a group can be exhausting, the more you are the easier it gets (plus you'll never be at a loss for speaker/paper ideas).
 
-* One way to get help is to join our #startingapwl Slack channel by [signing-up](http://papersweloveslack.herokuapp.com/)!
+* One way to get help is to [join the #startingapwl channel on our Discord](https://discord.gg/tdpeA72xEP)!
 
 * Ask someone you're really excited about to talk. [Michael Bernstein's blog](http://michaelrbernste.in/) was exactly the kind of thing we thought embodied the Papers We Love ethos, i.e. working/practicing programmers with an interest in keeping one toe in academia.
 


### PR DESCRIPTION
PWL migrated off of Slack some time ago and the Slack invite app on Heroku no longer works. This change updates the README to include an invite to the PWL Discord server. Since Discord allows invites to land in specific channels, I've generated a non-expiring invitation to the `#startingapwl` channel for this context.